### PR TITLE
[#77] Fix 404 issue with OPTIONS endpoints

### DIFF
--- a/proxy/app/controllers/cors_controller.rb
+++ b/proxy/app/controllers/cors_controller.rb
@@ -1,0 +1,11 @@
+# The controller to handle the OPTIONS requests for CORS, nocov because Rails
+# and RSpec deprecated or got rid of the ways to test OPTIONS requests.
+# :nocov:
+class CorsController < ApplicationController
+  # The endpoint for handling the OPTIONS requests
+  def preflight_check
+    add_cors_headers
+    render status: :ok
+  end
+end
+# :nocov:

--- a/proxy/config/routes.rb
+++ b/proxy/config/routes.rb
@@ -8,4 +8,6 @@ Rails.application.routes.draw do
   get '/Appointment', to: 'appointment#index'
   post '/Appointment', to: 'appointment#create'
   put '/Appointment/:id', to: 'appointment#update'
+
+  match '*all', to: 'cors#preflight_check', via: :options
 end


### PR DESCRIPTION
Issue #77 

- Add preflight endpoint to be used for `OPTIONS` requests