### PR TITLE
[#93] Fix 500 response for POST and PUT endpoints

### DIFF
--- a/proxy/lib/fhir_client.rb
+++ b/proxy/lib/fhir_client.rb
@@ -46,7 +46,11 @@ class FhirClient
   # @param [String] body
   # @return [OAuth2::Response]
   def post(path, base_url = "", body = "")
-    @token.post(base_url + path, body: body, headers: { "Accept": "application/json", "Content-Type": "application/json" })
+    @token.post(base_url + path, body: body,
+                                 headers: {
+                                   "Accept": "application/json",
+                                   "Content-Type": "application/json"
+                                 })
   end
 
   # Creates a PUT request to the FHIR API and returns the response. The base_url
@@ -57,6 +61,10 @@ class FhirClient
   # @param [String] body
   # @return [OAuth2::Response]
   def put(path, base_url = "", body = "")
-    @token.put(base_url + path, body: body, headers: { "Accept": "application/json", "Content-Type": "application/json" })
+    @token.put(base_url + path, body: body,
+                                headers: {
+                                  "Accept": "application/json",
+                                  "Content-Type": "application/json"
+                                })
   end
 end


### PR DESCRIPTION
Issue #93 

- Add `Content-Type` header to `POST` and `PUT` requests to prevent 500 responses from the FHIR API.