### PR TITLE
Store/Cache TimeSlots

### DIFF
--- a/clients/common/src/api/get-slots/index.ts
+++ b/clients/common/src/api/get-slots/index.ts
@@ -47,7 +47,7 @@ export const parseSlots = ({
   })
 }
 
-export const getTimeSlots = async ({
+export const getTimeSlots = ({
   setLoading,
   setError,
   setTimeSlots,

--- a/clients/common/src/api/get-slots/index.ts
+++ b/clients/common/src/api/get-slots/index.ts
@@ -7,6 +7,8 @@ import {
   ParseSlotsParamsType,
 } from './types'
 
+const DAYS_IN_MILLISECONDS = 86400000
+
 export const parseSlots = ({
   setLoading,
   responses,
@@ -65,7 +67,7 @@ export const getTimeSlots = ({
 
   Promise.all(
     providerIds.map(providerId => {
-      const end = new Date(date.getTime() + daysToFetch * 86400000)
+      const end = new Date(date.getTime() + daysToFetch * DAYS_IN_MILLISECONDS)
       return axios
         .get<IGetSlotsResponse>(`${api}/Slot`, {
           params: {

--- a/clients/common/src/api/get-slots/types.ts
+++ b/clients/common/src/api/get-slots/types.ts
@@ -44,7 +44,6 @@ export type ParseSlotsResponsesType = {
 export type ParseSlotsParamsType = {
   setLoading: SetLoadingType
   responses: ParseSlotsResponsesType
-  date: Date
   setTimeSlots: SetTimeSlotsType
   setError: SetErrorType
   api: string

--- a/clients/common/src/api/get-slots/types.ts
+++ b/clients/common/src/api/get-slots/types.ts
@@ -18,6 +18,7 @@ export type GetSlotsParamsType = {
   patientKey: string
   providerIds: string[]
   setProviders: (providers: ProvidersType[]) => void
+  daysToFetch: number
 }
 
 type SlotResourceType = {

--- a/clients/common/tests/api/getSlots.test.ts
+++ b/clients/common/tests/api/getSlots.test.ts
@@ -23,6 +23,7 @@ describe('getSlots', () => {
       patientId: 'fab73482a',
       patientKey: 'arbitraryString',
       date: new Date('2022-02-28T02:20:00.000Z'),
+      daysToFetch: 7,
       duration: 20,
       locationId: '1234',
       providerIds: ['1234567', '12345678'],
@@ -47,6 +48,7 @@ describe('getSlots', () => {
       locationId: '1234',
       providerIds: ['1234567', '12345678'],
       setProviders: () => {},
+      daysToFetch: 7,
     })
 
     expect(mockedAxios.get).toHaveBeenCalledTimes(5)
@@ -69,7 +71,6 @@ describe('getSlots', () => {
     parseSlots({
       setLoading: () => {},
       responses,
-      date: new Date('2022-03-28T10:00:00.000Z'),
       setTimeSlots,
       api: 'arbitraryString',
       patientId: 'fab73482a',

--- a/clients/scheduler/package.json
+++ b/clients/scheduler/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "webpack build --env prod",
     "build:esm": "webpack build --env prod --env esm",
+    "prepare": "npm run build",
     "start": "webpack server --open",
     "test": "TZ=UTC jest ./tests",
     "test:update": "yarn test --updateSnapshot"

--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact'
 import { isSameDay, ParsedSlotsType } from '@canvas-medical/embed-common'
-import { useState, useEffect, useMemo } from 'preact/hooks'
+import { useState, useEffect, useMemo, useCallback } from 'preact/hooks'
 import { useAppContext } from '../../hooks'
 import { Ui } from './ui'
 
@@ -8,7 +8,7 @@ export const TimeSlotSelect = () => {
   const { fetchTimeSlots, date } = useAppContext()
   const [providerTimeSlots, setProviderTimeSlots] = useState<ParsedSlotsType[]>([])
 
-  const addTimeSlots = (newProviderTimeSlots: ParsedSlotsType[]) => {
+  const addTimeSlots = useCallback((newProviderTimeSlots: ParsedSlotsType[]) => {
     const mergedProviderAvailability = newProviderTimeSlots.map((newProvider) => {
       const provider = providerTimeSlots.find((entry) => entry.providerId === newProvider.providerId)
       const mergedSlots = provider ? [...provider.providerSlots, ...newProvider.providerSlots] : newProvider.providerSlots
@@ -16,7 +16,7 @@ export const TimeSlotSelect = () => {
     })
 
     setProviderTimeSlots(mergedProviderAvailability)
-  }
+  }, [providerTimeSlots])
 
   // Determine max date available for all providers
   const maxDate = useMemo(() => {

--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -10,9 +10,18 @@ export const TimeSlotSelect = () => {
   const [dayOfTimeSlots, setDayOfTimeSlots] = useState<ParsedSlotsType[]>([])
   const [maxDate, setMaxDate] = useState<Date>(date)
 
+  const addTimeSlots = (newSlots: ParsedSlotsType[]) => {
+    const udpatedSlots = newSlots.map((newSlot) => {
+      const existingProvider = timeSlots.find((timeSlot) => timeSlot.providerId === newSlot.providerId)
+      const mergedSlots = existingProvider ? [...existingProvider.providerSlots, ...newSlot.providerSlots] : newSlot.providerSlots
+      return {providerId: newSlot.providerId, providerSlots: mergedSlots}
+    })
+    setTimeSlots(udpatedSlots)
+  }
+
   useEffect(() => {
     if (date >= maxDate) {
-      fetchTimeSlots(setTimeSlots)
+      fetchTimeSlots(addTimeSlots)
     }
   }, [date])
 

--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import { ParsedSlotsType } from '@canvas-medical/embed-common'
+import { isSameDay, ParsedSlotsType } from '@canvas-medical/embed-common'
 import { useState, useEffect } from 'preact/hooks'
 import { useAppContext } from '../../hooks'
 import { Ui } from './ui'
@@ -7,10 +7,46 @@ import { Ui } from './ui'
 export const TimeSlotSelect = () => {
   const { fetchTimeSlots, date } = useAppContext()
   const [timeSlots, setTimeSlots] = useState<ParsedSlotsType[]>([])
+  const [dayOfTimeSlots, setDayOfTimeSlots] = useState<ParsedSlotsType[]>([])
+  const [maxDate, setMaxDate] = useState<Date>(date)
 
   useEffect(() => {
-    fetchTimeSlots(setTimeSlots)
+    if (date >= maxDate) {
+      fetchTimeSlots(setTimeSlots)
+    }
   }, [date])
 
-  return <Ui timeSlots={timeSlots} />
+  useEffect(() => {
+    setDayOfTimeSlots(timeSlots.map((provider) => {
+      return {
+        providerId: provider.providerId,
+        providerSlots: provider.providerSlots.filter((slot) => {
+          return isSameDay(new Date(slot.start), date)
+        })
+      }
+    }))
+  }, [date, timeSlots])
+
+  // Determine max date available for all providers
+  useEffect(() => {
+    if (timeSlots.length === 0) {
+      return
+    }
+
+    const providersMaxDates = timeSlots.map((provider) => {
+      return provider.providerSlots.reduce((a, b) => {
+        return new Date(a.start) > new Date(b.start) ? a : b;
+      })
+    })
+
+    const maxDateSlot = providersMaxDates.reduce((a, b) => {
+      return new Date(a.start) > new Date(b.start) ? a : b;
+    })
+
+    setMaxDate(new Date(maxDateSlot.start))
+  }, [timeSlots])
+
+
+
+  return <Ui timeSlots={dayOfTimeSlots} />
 }

--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -1,48 +1,30 @@
 import { h } from 'preact'
 import { isSameDay, ParsedSlotsType } from '@canvas-medical/embed-common'
-import { useState, useEffect } from 'preact/hooks'
+import { useState, useEffect, useMemo } from 'preact/hooks'
 import { useAppContext } from '../../hooks'
 import { Ui } from './ui'
 
 export const TimeSlotSelect = () => {
   const { fetchTimeSlots, date } = useAppContext()
-  const [timeSlots, setTimeSlots] = useState<ParsedSlotsType[]>([])
-  const [dayOfTimeSlots, setDayOfTimeSlots] = useState<ParsedSlotsType[]>([])
-  const [maxDate, setMaxDate] = useState<Date>(date)
+  const [providerTimeSlots, setProviderTimeSlots] = useState<ParsedSlotsType[]>([])
 
-  const addTimeSlots = (newSlots: ParsedSlotsType[]) => {
-    const udpatedSlots = newSlots.map((newSlot) => {
-      const existingProvider = timeSlots.find((timeSlot) => timeSlot.providerId === newSlot.providerId)
-      const mergedSlots = existingProvider ? [...existingProvider.providerSlots, ...newSlot.providerSlots] : newSlot.providerSlots
-      return {providerId: newSlot.providerId, providerSlots: mergedSlots}
+  const addTimeSlots = (newProviderTimeSlots: ParsedSlotsType[]) => {
+    const mergedProviderAvailability = newProviderTimeSlots.map((newProvider) => {
+      const provider = providerTimeSlots.find((entry) => entry.providerId === newProvider.providerId)
+      const mergedSlots = provider ? [...provider.providerSlots, ...newProvider.providerSlots] : newProvider.providerSlots
+      return {providerId: newProvider.providerId, providerSlots: mergedSlots}
     })
-    setTimeSlots(udpatedSlots)
+
+    setProviderTimeSlots(mergedProviderAvailability)
   }
 
-  useEffect(() => {
-    if (date >= maxDate) {
-      fetchTimeSlots(addTimeSlots)
-    }
-  }, [date])
-
-  useEffect(() => {
-    setDayOfTimeSlots(timeSlots.map((provider) => {
-      return {
-        providerId: provider.providerId,
-        providerSlots: provider.providerSlots.filter((slot) => {
-          return isSameDay(new Date(slot.start), date)
-        })
-      }
-    }))
-  }, [date, timeSlots])
-
   // Determine max date available for all providers
-  useEffect(() => {
-    if (timeSlots.length === 0) {
+  const maxDate = useMemo(() => {
+    if (providerTimeSlots.length === 0) {
       return
     }
 
-    const providersMaxDates = timeSlots.map((provider) => {
+    const providersMaxDates = providerTimeSlots.map((provider) => {
       if (provider.providerSlots.length === 0) {
         return undefined
       }
@@ -61,11 +43,26 @@ export const TimeSlotSelect = () => {
     })
 
     if (maxDateSlot) {
-      setMaxDate(new Date(maxDateSlot.start))
+      return new Date(maxDateSlot.start)
     }
-  }, [timeSlots])
+  }, [providerTimeSlots])
 
+  useEffect(() => {
+    if (typeof maxDate === "undefined" || date >= maxDate) {
+      fetchTimeSlots(addTimeSlots)
+    }
+  }, [date])
 
+  const dayOfTimeSlots = useMemo(() => {
+    return providerTimeSlots.map((provider) => {
+      return {
+        providerId: provider.providerId,
+        providerSlots: provider.providerSlots.filter((slot) => {
+          return isSameDay(new Date(slot.start), date)
+        })
+      }
+    })
+  }, [date, providerTimeSlots])
 
   return <Ui timeSlots={dayOfTimeSlots} />
 }

--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -34,16 +34,26 @@ export const TimeSlotSelect = () => {
     }
 
     const providersMaxDates = timeSlots.map((provider) => {
+      if (provider.providerSlots.length === 0) {
+        return undefined
+      }
+
       return provider.providerSlots.reduce((a, b) => {
         return new Date(a.start) > new Date(b.start) ? a : b;
       })
     })
 
     const maxDateSlot = providersMaxDates.reduce((a, b) => {
+      if (!a || !b) {
+        return undefined
+      }
+
       return new Date(a.start) > new Date(b.start) ? a : b;
     })
 
-    setMaxDate(new Date(maxDateSlot.start))
+    if (maxDateSlot) {
+      setMaxDate(new Date(maxDateSlot.start))
+    }
   }, [timeSlots])
 
 

--- a/clients/scheduler/src/hooks/app-context.tsx
+++ b/clients/scheduler/src/hooks/app-context.tsx
@@ -21,6 +21,7 @@ export const AppContext = createContext<IAppContext>({
   api: '',
   appointmentCoding: {},
   bailoutURL: '',
+  daysToFetch: 7,
   duration: 20,
   locationId: '',
   patientId: '',
@@ -94,6 +95,7 @@ export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
         duration: values.duration,
         setTimeSlots,
         setProviders,
+        daysToFetch: values.daysToFetch,
       })
     },
     [date, values]

--- a/clients/scheduler/src/index.tsx
+++ b/clients/scheduler/src/index.tsx
@@ -10,6 +10,7 @@ export const Scheduler = (props: ISchedulerProps) => {
     api,
     appointmentCoding,
     bailoutURL,
+    daysToFetch,
     duration,
     locationId,
     patientId,
@@ -41,6 +42,7 @@ export const Scheduler = (props: ISchedulerProps) => {
             patientKey,
             providerIds,
             colors,
+            daysToFetch,
             description,
             returnURL,
             shadowRoot,
@@ -87,6 +89,7 @@ export const init = ({
   patientId,
   patientKey,
   providerIds,
+  daysToFetch = 7,
   description,
   returnURL,
   rootId,
@@ -119,6 +122,7 @@ export const init = ({
       api={api}
       appointmentCoding={appointmentCoding}
       bailoutURL={bailoutURL}
+      daysToFetch={daysToFetch}
       duration={duration}
       locationId={locationId}
       patientId={patientId}

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -10,6 +10,7 @@ export interface IMainAppProps {
   api: string
   appointmentCoding: AppointmentCodingType
   bailoutURL: string
+  daysToFetch: number
   duration: number
   locationId: string
   patientId: string


### PR DESCRIPTION
## Description

`Slot`s that are retrieved from the FHIR API are now stored/cached on the client. The number of available days to pre-fetch from the FHIR API is configurable via the `daysToFetch` prop.

## Problem

When retrieving `Slot`s from the FHIR API, no `end` parameter is provided which results in a non-obvious/unpredictable set of dates with available time slots. The current solution for this is to utilize the `isSameDay` helper function to "throw out" any `Slot` with start date that doesn't match the currently selected date in the Scheduler. Due to the latency of the FHIR API this causes a significant amount of wait time _every_ time the user clicks the navigation to query for the next days availability.

## Solution

We can set a configurable `end` time when we call the `/Slot` endpoint via an additional prop. Rather than "throwing out" data, we can store/cache any previous results from the FHIR API on the client and "paginate" through the local data until we no longer have data for the selected date.


## Summary of changes

- Added a new Scheduler prop: `daysToFetch`
  - Default of 7 if it is not provided: [as reported in the API documentation](https://docs.canvasmedical.com/reference/search-2)
  
![image](https://user-images.githubusercontent.com/23412794/166933124-d80ba925-8dc9-49cb-85c5-8d006b4a991f.png)

- Repurposed the existing `timeSlots` state to store _all_ previously fetched `Slot`s
  - In order to preserve backwards date searching (after fetching new `Slot`s from the API) we append all new slots to any previous `Slot`s we have already received.
  
  - `timeSlots` becomes a continually updated set of all available `Slot`s that have been retrieved in the current client session
- Moved the `isSameDay` helper function check from the common `getTimeSlots` API call to the `time-slot-select` component to build out a `dayOfTimeSlots` state
  - This is passed into the UI, as opposed to the entire list of available `Slot`s
- Added logic to track the maximum date available to schedule
  - When the selected date advances beyond what is available locally, we fetch new `Slot`s.
  - This allows us to only make a high latency API call when absolutely necessary
